### PR TITLE
Replace depricated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const through = require('through2');
-const gutil = require('gulp-util');
-const PluginError = gutil.PluginError;
+const log = require('fancy-log');
+const PluginError = require('plugin-error');
 const pngquant = require('pngquant-bin');
 const execFileSync = require('child_process').execFileSync;
 const spawnSync = require('child_process').spawnSync;
@@ -39,7 +39,7 @@ function gulpPngquant(options, customPngquantPath) {
         // tell the stream engine that we are done with this file
         cb();
     }, function(flush) {
-        gutil.log('Finished', '\'' + chalk.cyan(PLUGIN_NAME));
+        log('Finished', '\'' + chalk.cyan(PLUGIN_NAME));
         flush();
     });
 

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "author": "leidottw",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^1.1.3",
+    "chalk": "^3.0.0",
     "fancy-log": "^1.3.3",
     "plugin-error": "^1.0.1",
-    "pngquant-bin": "^3.1.1",
-    "through2": "^2.0.1"
+    "pngquant-bin": "^5.0.2",
+    "through2": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
   "author": "leidottw",
   "license": "MIT",
   "dependencies": {
-    "chalk": "1.1.3",
-    "gulp-util": "3.0.7",
-    "pngquant-bin": "3.1.1",
-    "through2": "2.0.1"
+    "chalk": "^1.1.3",
+    "fancy-log": "^1.3.3",
+    "plugin-error": "^1.0.1",
+    "pngquant-bin": "^3.1.1",
+    "through2": "^2.0.1"
   }
 }


### PR DESCRIPTION
gulp-util is deprecated, see:

- https://www.npmjs.com/package/gulp-util
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5